### PR TITLE
Adding auto_need method for auto-including Form resources

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 CHANGES
 =======
 
+0.9.5-2
+-------
+
+-   Add ``auto_need`` method for automatically including Fanstatic resources
+    for a given Deform form instance.
+
 0.9.5-1
 -------
 

--- a/js/deform/__init__.py
+++ b/js/deform/__init__.py
@@ -3,6 +3,7 @@
 from fanstatic import Group
 from fanstatic import Library
 from fanstatic import Resource
+from fanstatic.wsgi import resolve
 from js.jquery import jquery
 from pkg_resources import resource_filename
 
@@ -29,3 +30,104 @@ deform_beautify_css = Resource(
 deform_css = Group([deform_form_css, deform_beautify_css, ])
 
 deform = Group([deform_css, deform_js, ])
+
+#Deform widget dependencies
+deform_jqueryui_css = Resource(
+    library,
+    "css/ui-lightness/jquery-ui-1.8.11.custom.css")
+deform_jqueryui_js = Resource(
+    library,
+    "scripts/jquery-ui-1.8.11.custom.min.js",
+    depends=[jquery])
+deform_jqueryui = Group([deform_jqueryui_css, deform_jqueryui_js])
+
+deform_jquery_time_picker_addon_css = Resource(
+    library,
+    "css/jquery-ui-timepicker-addon.css")
+deform_jquery_time_picker_addon_js = Resource(
+    library,
+    "scripts/jquery-ui-timepicker-addon.js",
+    depends=[deform_jqueryui])
+deform_jquery_time_picker_addon = Group([deform_jquery_time_picker_addon_css,
+                                         deform_jquery_time_picker_addon_js])
+
+deform_jquery_form = Resource(
+    library,
+    "scripts/jquery.form-3.09.js",
+    depends=[jquery])
+
+deform_jquery_maskmoney = Resource(
+    library,
+    "scripts/jquery.maskMoney-1.4.1.js",
+    depends=[jquery])
+
+deform_jquery_maskedinput = Resource(
+    library,
+    "scripts/jquery.maskedinput-1.2.2.min.js",
+    depends=[jquery])
+
+deform_tinymce = Resource(
+    library,
+    "tinymce/jscripts/tiny_mce/tiny_mce.js",
+    depends=[jquery])
+
+resource_mapping = {
+    'datetimepicker': ['js.jquery_timepicker_addon.timepicker',
+                       deform_jquery_time_picker_addon],
+    'deform': [deform],
+    'jquery': ['js.jquery.jquery'],
+    'jquery.form': ['js.jquery_form.jquery_form',
+                    deform_jquery_form],
+    'jquery.maskMoney': ['js.jquery_maskmoney.jquery_maskmoney',
+                         deform_jquery_maskmoney],
+    'jquery.maskedinput': ['js.jquery_maskedinput.jquery_maskedinput',
+                           deform_jquery_maskedinput],
+    'jqueryui': ['js.jqueryui.jqueryui',
+                 deform_jqueryui],
+    'tinymce': ['js.tinymce.tinymce',
+                deform_tinymce]
+}
+
+def try_resolve(name):
+    """Attempt to load the given object referred to by ``name``.
+
+    This function automatically returns ``name`` if this object is anything
+    but a string.
+    """
+    if type(name) != str:
+        return name
+
+    obj = None
+    try:
+        obj = resolve(name)
+    except:
+        pass
+    return obj
+
+def auto_need(form):
+    """Automatically ``need()`` the relevant Fanstatic resources for a form.
+
+    This function automatically utilises libraries in the ``js.*`` namespace
+    if they're available (such as ``js.jquery``, ``js.tinymce`` and so
+    forth) to allow Fanstatic to better manage these resources (caching,
+    minifications) and avoid duplication across the rest of your
+    application.
+
+    If you don't have a certain library installed, then this function
+    will fall back to using that which is automatically provided as a
+    static resource within `Deform`.
+    """
+    requirements = form.get_widget_requirements()
+    for library, version in requirements:
+        potentials = resource_mapping[library]
+        found = None
+        for lib in potentials:
+            found = try_resolve(lib)
+            if found:
+                break
+        if found:
+            found.need()
+        else:
+            raise ImportError("Can't locate a library for %s" % library)
+
+

--- a/js/deform/test_deform.txt
+++ b/js/deform/test_deform.txt
@@ -19,7 +19,6 @@ it where you want these resources to be included on a page::
   >>> from js.deform import deform_css
   >>> deform_css.need()
 
-
 All
 ---
 
@@ -28,3 +27,80 @@ it where you want these resources to be included on a page::
 
   >>> from js.deform import deform
   >>> deform.need()
+
+Auto-needing Resources
+----------------------
+
+You can avoid needing to manually import and ``need()`` each
+Fanstatic dependency of your ``Deform`` form by use of the ``auto_need``
+function provided in this package. 
+
+  >>> import js.deform
+  >>> import colander
+  >>> import deform
+
+  >>> schema = colander.Schema()
+  >>> form = deform.Form(schema)
+  >>> js.deform.auto_need(form)
+
+By doing the above, any widget requirements - including those of `Deform`
+itself - will be included for Fanstatic.
+
+This function will automatically detect if you have dedicated Fanstatic
+libraries (such as ``js.jquery`` or ``js.jqueryui`` and so forth) installed
+that relate to various widget dependencies. This function
+will use these over the pre-bundled resources that ship with Deform. By
+using these dedicated libraries, you can improve efficiency and code
+portability, especially if you use the libraries elsewhere in your
+application. Depending on the packaging of the given library, your page
+weight is likely to benefit from minified versions being available and
+so forth. For more information see the listing of `Pre-packaged libraries
+<http://www.fanstatic.org/en/latest/libraries.html>`_.
+
+So, you may have a form that requires a ``deform.widget.RichTextWidget``
+for one of its fields.  This type of widget requires resources relating to 
+`TinyMCE`. If you already have ``js.tinymce`` installed and available for
+import in Python, then ``js.deform.auto_need`` will use this.
+If this library, or indeed others you need, aren't present, then Deform's
+defaults will be included for Fanstatic to serve as a fallback. 
+
+This is all best illustrated in the following example.
+
+Initialise Fanstatic so we can see resources being included:
+
+  >>> import fanstatic
+  >>> dummy = fanstatic.init_needed()
+  >>> len(fanstatic.get_needed().resources())
+  0
+
+Create a demonstration schema and form:
+
+  >>> schema = colander.Schema()
+  >>> node = colander.SchemaNode(colander.String(),
+  ...                            widget=deform.widget.RichTextWidget())
+  >>> schema.add(node)
+  >>> form = deform.Form(schema)
+
+Check the form's resource requirements:
+
+  >>> form.get_widget_requirements()
+  [('deform', None), ('tinymce', None)]
+
+Ask ``auto_need`` to include the resources for us:
+
+  >>> js.deform.auto_need(form)
+
+So we can now see the resources that have been included:
+
+  >>> needed = fanstatic.get_needed()
+  >>> needed.resources()
+  [<Resource 'css/beautify.css' in library 'deform'>, <Resource 'css/form.css' in library 'deform'>, <Resource 'jquery.js' in library 'jquery'>, <Resource 'scripts/deform.js' in library 'deform'>, <Resource 'tinymce/jscripts/tiny_mce/tiny_mce.js' in library 'deform'>]
+
+The above resources will automatically be included on your page once
+Fanstatic is configured accordingly. 
+
+As you can see, the resources being included come from Deform. The one
+exception to this is jQuery, which comes from ``js.jquery``, a dependency
+of this library. As mentioned above, if you have other libraries available
+related to widgets on your form, then they will be used over those from 
+Deform.


### PR DESCRIPTION
For a given form instance, one can now run `js.deform.auto_need(form)` and have the Fanstatic resources automatically included.

This pull request includes doctests within the given test_deform.txt file -- these succeed when being run under pytest.  That said, I've hesitated with regards to defining a test dependency for this package right now -- thoughts?

The additional definitions of the Deform bundled resources are too brittle for my liking - as they'll break when a version changes within Deform - so having a better solution here would be a definite plus. 

The only additional thing on my mind is that this code ignores any particular version requirements that Deform suggests (eg everything defined in `deform.widget.default_resources` states no particular version requirements for all libraries at present (eg the 'None' values in the dicts), but this could change in the future.
