### PR TITLE
Add deform_basic for including just the default CSS and JS (not "beautify")

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ CHANGES
 0.9.7 - unreleased
 ------------------
 
-
+- Add ``deform_basic`` to the available resource groupings. Using this
+  includes just the basic CSS and JavaScript, without the 'beautify' CSS.
+  [davidjb]
 
 0.9.6 - 2013-02-23
 ------------------

--- a/js/deform/__init__.py
+++ b/js/deform/__init__.py
@@ -37,6 +37,7 @@ deform_beautify_css = Resource(
 
 deform_css = Group([deform_form_css, deform_beautify_css, ])
 
+deform_basic = Group([deform_form_css, deform_js, ])
 deform = Group([deform_css, deform_js, ])
 
 resource_mapping = {

--- a/js/deform/tests/test_deform.txt
+++ b/js/deform/tests/test_deform.txt
@@ -19,6 +19,17 @@ it where you want these resources to be included on a page::
   >>> from js.deform import deform_css
   >>> deform_css.need()
 
+This will include Deform's default ``form.css`` as well as the
+``beautify.css``.  If you only want one or the other, you can
+``need`` them like so::
+
+  >>> from js.deform import deform_form_css
+  >>> deform_form_css.need()
+
+  >>> from js.deform import deform_beautify_css
+  >>> deform_beautify_css.need()
+
+
 All
 ---
 
@@ -27,6 +38,10 @@ it where you want these resources to be included on a page::
 
   >>> from js.deform import deform
   >>> deform.need()
+
+This automatically includes all of Deform's CSS and JS and is
+the equivalent to needing both ``deform_js`` and ``deform_css``
+as described above.
 
 Auto-needing Resources
 ----------------------


### PR DESCRIPTION
Also adds extra documentation on what the various groupings result in.
