### PR TITLE
Remove deform_beautify_css

### DIFF
--- a/js/deform/__init__.py
+++ b/js/deform/__init__.py
@@ -34,11 +34,8 @@ deform_js = Resource(
 deform_form_css = Resource(
     library,
     "css/form.css")
-deform_beautify_css = Resource(
-    library,
-    "css/beautify.css")
 
-deform_css = Group([deform_form_css, deform_beautify_css, ])
+deform_css = Group([deform_form_css, ])
 
 deform_basic = Group([deform_form_css, deform_js, ])
 deform = Group([deform_css, deform_js, ])

--- a/js/deform/tests/test_deform.txt
+++ b/js/deform/tests/test_deform.txt
@@ -19,17 +19,6 @@ it where you want these resources to be included on a page::
   >>> from js.deform import deform_css
   >>> deform_css.need()
 
-This will include Deform's default ``form.css`` as well as the
-``beautify.css``.  If you only want one or the other, you can
-``need`` them like so::
-
-  >>> from js.deform import deform_form_css
-  >>> deform_form_css.need()
-
-  >>> from js.deform import deform_beautify_css
-  >>> deform_beautify_css.need()
-
-
 All
 ---
 


### PR DESCRIPTION
The file deform/static/css/beautify.css was removed in
https://github.com/Pylons/deform/commit/366355c17b334f5c203e443453f85bda47161abd

Fixes error:

```
    from js.deform import deform_form_css

  File "/app/.venv/lib/python3.7/site-packages/js/deform/__init__.py", line 39, in <module>

    "css/beautify.css")

  File "/app/.venv/lib/python3.7/site-packages/fanstatic/core.py", line 400, in __init__

    "Resource file does not exist: %s" % path)

fanstatic.core.UnknownResourceError: Resource file does not exist: /app/.venv/lib/python3.7/site-packages/deform/static/css/beautify.css
```