### PR TITLE
Re-add support for Python 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
 python:
+  - 2.7
   - 3.6
   - 3.7
   - 3.8
   - 3.9-dev
+  - pypy
   - pypy3
 before_install:
   - pip freeze | xargs pip uninstall -y

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ CHANGES
 
 - Add support for Python 3.6 up to 3.9 and PyPy3.
 
-- Drop support for Python 2.7, PyPy2, 3.4 and 3.5
+- Drop support for Python 3.4 and 3.5.
 
 - Adapt to ``deform >= 2.0.11``.
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setup(
         "Development Status :: 6 - Mature",
         "Intended Audience :: Developers",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
 envlist =
+          py27,
           py36,
           py37,
           py38,
           py39,
+          pypy,
           pypy3,
 
 [testenv]


### PR DESCRIPTION
As deform did not drop support for Python 2, there is no need to drop it here.

See https://github.com/Pylons/deform/issues/478